### PR TITLE
Add API integration for content generation and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ __pypackages__/
 # Pipfile.lock
 # poetry.lock
 # pdm.lock
+API_key.yaml
+raw_data/document_to_anonymize.txt
+tutorials/pdf__to__txt.ipynb
+tutorials/pdf__to__txt.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -182,4 +182,3 @@ __pypackages__/
 API_key.yaml
 raw_data/document_to_anonymize.txt
 tutorials/pdf__to__txt.ipynb
-tutorials/pdf__to__txt.ipynb

--- a/Api_prompt.py
+++ b/Api_prompt.py
@@ -1,0 +1,45 @@
+import requests
+import yaml
+import os
+# Replace this with your actual API key
+with open(os.path.abspath("nos-gen-ai-hackathon/API_key.yaml"), 'r') as file:
+    keys = yaml.safe_load(file)
+API_KEY = keys["GOOGLE_API_KEY"]
+API_URL = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={API_KEY}"
+
+def generate_content(prompt_text: str, temperature: float) -> dict:
+    """Generates content based on the given prompt text and temperature.
+
+    Args:
+        prompt_text (str): The text prompt to generate content from.
+        temperature (float): The temperature parameter for controlling randomness.
+    """
+
+    headers = {
+        "Content-Type": "application/json"
+    }
+
+    body = {
+        "contents": [
+            {
+                "parts": [
+                    {"text": prompt_text}
+                ]
+            }
+        ],
+        "generationConfig": {
+            "temperature": temperature
+        }
+    }
+
+    response = requests.post(API_URL, headers=headers, json=body)
+
+    return response.json()
+
+# Example usage
+prompt = "Tell me a one sentence story"
+output = generate_content(prompt, 0.0)
+# Get only the response text
+response_text = output['candidates'][0]['content']['parts'][0]['text']
+
+print(response_text)


### PR DESCRIPTION
This pull request introduces a new function to interact with the Google Generative Language API for content generation. It includes setting up API key management, defining a `generate_content` function, and demonstrating its usage with an example.

### New functionality for content generation:
* `Api_prompt.py`: Added a `generate_content` function to send prompts to the Google Generative Language API and retrieve generated content. This includes:
  - Loading the API key from a YAML file for secure management.
  - Constructing the API request with headers and a JSON body, including support for the `temperature` parameter to control randomness.
  - Parsing the API response to extract and return the generated content.

### Example usage:
* [`Api_prompt.py`](diffhunk://#diff-83f2130456efe46d67b880cfb12757ca0443a9ed42e1031db8077d5b17834b15R1-R45): Included an example usage of the `generate_content` function, demonstrating how to generate a one-sentence story and print the response text.