### PR TITLE
Add API key setup prompt if not present

### DIFF
--- a/Api_prompt.py
+++ b/Api_prompt.py
@@ -1,10 +1,17 @@
 import requests
 import yaml
 import os
+API_KEY_FILE = os.path.abspath("nos-gen-ai-hackathon/API_key.yaml")
+if (os.path.exists("nos-gen-ai-hackathon/API_key.yaml") == False):
+    with open(API_KEY_FILE, 'w') as file:
+        key = input("You don't have a key set yet. Please enter your Google API key:\n")
+        file.write(f"GOOGLE_API_KEY: {key}")
+        
 # Replace this with your actual API key
 with open(os.path.abspath("nos-gen-ai-hackathon/API_key.yaml"), 'r') as file:
     keys = yaml.safe_load(file)
-API_KEY = keys["GOOGLE_API_KEY"]
+    
+API_KEY = keys["GOOGLE_API_KEY"] 
 API_URL = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={API_KEY}"
 
 def generate_content(prompt_text: str, temperature: float) -> dict:


### PR DESCRIPTION
This pull request introduces a mechanism to handle missing API keys in the `Api_prompt.py` file. If the required `API_key.yaml` file does not exist, the script will prompt the user to input their Google API key and create the file with the provided key.

### Key Changes:
#### API Key Handling:
* Added logic to check if the `API_key.yaml` file exists. If it does not, the script will prompt the user to enter their Google API key, which will then be saved in a newly created `API_key.yaml` file. (`[Api_prompt.pyR4-R13](diffhunk://#diff-83f2130456efe46d67b880cfb12757ca0443a9ed42e1031db8077d5b17834b15R4-R13)`)